### PR TITLE
TUI: Update every 0.1%, show %complete, iters complete, it/s, ETA

### DIFF
--- a/crates/client/src/constants.rs
+++ b/crates/client/src/constants.rs
@@ -1,4 +1,4 @@
-pub const PROGRESS_BAR_STEPS: u64 = 20;
+pub const PROGRESS_BAR_STEPS: u64 = 1_000;  // Report every 0.1%
 
 pub fn default_classgroup_element() -> [u8; 100] {
     let mut el = [0u8; 100];

--- a/crates/client/src/ui.rs
+++ b/crates/client/src/ui.rs
@@ -1,16 +1,14 @@
 use std::io::Write;
 
-use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
 
 use bbr_client_engine::JobSummary;
 
-use crate::constants::PROGRESS_BAR_STEPS;
 use crate::format::{field_vdf_label, format_number};
 
 struct WorkerUiState {
     bar: ProgressBar,
     total_iters: u64,
-    last_step: u64,
 }
 
 pub(crate) struct Ui {
@@ -32,20 +30,23 @@ impl Ui {
         global_pb.set_message("Global: 0 it/s");
 
         let worker_style =
-            ProgressStyle::with_template("{prefix} {bar:20.cyan/blue} {msg}\u{1b}[0K")
+            ProgressStyle::with_template("{prefix}  {percent:>3}%[{bar:20.cyan/blue}] {human_pos:>11} it  {iters_per_sec:>12}  {eta_precise} ETA   {msg}\u{1b}[0K")
             .unwrap()
+            .with_key("iters_per_sec", |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                let _ = write!(w, "{} it/s", format_number(state.per_sec() as u64));
+            })
             .progress_chars("#--");
 
         let mut worker_states = Vec::with_capacity(worker_count);
+        let width = worker_count.max(1).ilog10() as usize + 1;
         for idx in 0..worker_count {
-            let pb = mp.add(ProgressBar::new(PROGRESS_BAR_STEPS));
+            let pb = mp.add(ProgressBar::new(1));
             pb.set_style(worker_style.clone());
-            pb.set_prefix(format!("W{}", idx + 1));
+            pb.set_prefix(format!("W{:0width$}", idx + 1));
             pb.set_message("Idle");
             worker_states.push(WorkerUiState {
                 bar: pb,
                 total_iters: 0,
-                last_step: 0,
             });
         }
 
@@ -70,11 +71,11 @@ impl Ui {
         let Some(state) = self.worker_states.get_mut(worker_idx) else {
             return;
         };
-        state.bar.set_length(PROGRESS_BAR_STEPS);
+        state.bar.reset_elapsed();
+        state.bar.set_length(total_iters);
         state.bar.set_position(0);
         state.bar.set_message(msg);
         state.total_iters = total_iters;
-        state.last_step = 0;
     }
 
     pub(crate) fn set_worker_job(&mut self, worker_idx: usize, job: &JobSummary) {
@@ -99,21 +100,18 @@ impl Ui {
         let Some(state) = self.worker_states.get_mut(worker_idx) else {
             return;
         };
-        let step = calc_progress_step(state.total_iters, iters_done);
-        if step != state.last_step {
-            state.last_step = step;
-            state.bar.set_position(step);
-        }
+        state.bar.set_position(iters_done);
     }
 
     pub(crate) fn set_worker_idle(&mut self, worker_idx: usize) {
         let Some(state) = self.worker_states.get_mut(worker_idx) else {
             return;
         };
+        state.bar.reset_elapsed();
+        state.bar.set_length(1);
         state.bar.set_position(0);
         state.bar.set_message("Idle".to_string());
         state.total_iters = 0;
-        state.last_step = 0;
     }
 
     pub(crate) fn set_stop_message(&mut self, msg: &str) {
@@ -135,25 +133,5 @@ impl Ui {
         self.global_pb.abandon();
         self.stop_pb.abandon();
         let _ = std::io::stdout().write_all(b"\n");
-    }
-}
-
-fn calc_progress_step(total_iters: u64, iters_done: u64) -> u64 {
-    let total = total_iters.max(1);
-    let iters_done = iters_done.min(total_iters);
-    ((iters_done.saturating_mul(PROGRESS_BAR_STEPS)) / total).min(PROGRESS_BAR_STEPS)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn calc_progress_step_clamps_and_scales() {
-        let steps = PROGRESS_BAR_STEPS;
-        assert_eq!(calc_progress_step(100, 0), 0);
-        assert_eq!(calc_progress_step(100, 50), steps / 2);
-        assert_eq!(calc_progress_step(100, 100), steps);
-        assert_eq!(calc_progress_step(100, 1000), steps);
     }
 }


### PR DESCRIPTION
Cosmetically improves the TUI progress bars, to show output like the following:
```
W01   29%[#####---------------] 149,469,120 it   63,387 it/s  01:37:09 ETA   Group 8 proofs
W02   23%[####----------------] 100,257,465 it   63,563 it/s  01:27:30 ETA   Group 8 proofs
W03   88%[#################---] 481,622,240 it   64,400 it/s  00:16:59 ETA   Group 8 proofs
W04   97%[###################-] 542,085,544 it   73,571 it/s  00:03:24 ETA   Group 8 proofs
W05   50%[##########----------] 100,080,904 it   69,447 it/s  00:23:43 ETA   Group 8 proofs
W06   20%[###-----------------]  49,525,209 it   62,110 it/s  00:54:10 ETA   Group 8 proofs
W07   60%[############--------] 130,233,600 it   63,558 it/s  00:22:46 ETA   Group 8 proofs
W08   39%[#######-------------] 141,086,010 it   62,374 it/s  00:58:57 ETA   Group 8 proofs
W09   48%[#########-----------] 238,761,120 it   61,310 it/s  01:10:18 ETA   Group 8 proofs
W10    9%[#-------------------]  38,882,348 it   61,526 it/s  01:41:31 ETA   Group 8 proofs
```

Most importantly, "progress bar steps" is changed to update much more frequently: every 0.1%. (Current VDFs average to 280M iterations, so that's every ~280K iterations on average -- or every ~4 seconds for 70K it/s CPU threads.) I haven't double-checked if changing this PROGRESS_BAR_STEPS constant has any adverse effects on non-TUI parts, like the GUI.